### PR TITLE
complete:learn-next chapter:5

### DIFF
--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -1,8 +1,12 @@
+'use client'
 import {
   UserGroupIcon,
   HomeIcon,
   DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import {usePathname} from 'next/navigation';
+import clsx from 'clsx';
 
 // Map of links to display in the side navigation.
 // Depending on the size of the application, this would be stored in a database.
@@ -17,19 +21,25 @@ const links = [
 ];
 
 export default function NavLinks() {
+  const pathname = usePathname();
   return (
     <>
       {links.map((link) => {
         const LinkIcon = link.icon;
         return (
-          <a
+          <Link
             key={link.name}
             href={link.href}
-            className="flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3"
+            className={clsx(
+              'flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3',
+              {
+                'bg-sky-100 text-blue-600': pathname === link.href,
+              },
+            )}
           >
             <LinkIcon className="w-6" />
             <p className="hidden md:block">{link.name}</p>
-          </a>
+          </Link>
         );
       })}
     </>


### PR DESCRIPTION
## 概要
`next/link`の`Link`コンポーネントを利用して、ダッシュボードのナビゲーションリンクの実装方法をデモします。

## 変更点
- `'use client'`を追加して、クライアントサイドでのみ実行されることをNext.jsに示しました。
- `next/link`から`Link`コンポーネントをインポートし、従来の`<a>`タグに代わるものとして使用しました。
- `next/navigation`から`usePathname`フックをインポートし、現在のパス名を取得しています。
- `clsx`をインポートして、条件付きでクラス名を組み合わせることができるようにしました。
- ナビゲーションリンクを`Link`コンポーネントでラップし、アプリ内のナビゲーションをより効率的かつアクセシブルにしました。
